### PR TITLE
add support socks5 server type

### DIFF
--- a/common/options.go
+++ b/common/options.go
@@ -32,4 +32,5 @@ type Options struct {
 	MaxErrors    int
 	MaxRedirects int
 	MaxRetries   int
+	Type         string
 }

--- a/common/vars.go
+++ b/common/vars.go
@@ -49,10 +49,12 @@ Options:
         --max-redirs <N>             Max. redirects allowed (default: 10)
     -s, --sync                       Syncrounus mode
     -w, --watch                      Watch proxy file, live-reload from changes
+    	--type                       http or socks5 proxy server type ( default: http )
 
 Examples:
   mubeng -f proxies.txt --check --output live.txt
   mubeng -a localhost:8080 -f live.txt -r 10 -w
+  mubeng -a localhost:8080 -f live.txt -r 10 -w --type socks5
 
 `
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/mubeng/mubeng
 
-go 1.21
+go 1.22
+
 toolchain go1.23.4
 
 require (
@@ -14,6 +15,7 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-test/deep v1.1.1
 	github.com/gosimple/slug v1.15.0
+	github.com/h12w/go-socks5 v0.0.0-20200522160539-76189e178364
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/henvic/httpretty v0.1.4
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
@@ -23,8 +25,10 @@ require (
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/sourcegraph/conc v0.3.0
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e
+	github.com/things-go/go-socks5 v0.0.5
 	github.com/valyala/fastrand v1.1.0
 	github.com/valyala/fasttemplate v1.2.2
+	golang.org/x/net v0.34.0
 	h12.io/socks v1.0.3
 )
 
@@ -56,7 +60,6 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e h1:IWllFTiDjjLIf2oeKxpIUmtiDV5sn71VgeQgg6vcE7k=
 github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e/go.mod h1:d7u6HkTYKSv5m6MCKkOQlHwaShTMl3HjqSGW3XtVhXM=
+github.com/things-go/go-socks5 v0.0.5 h1:qvKaGcBkfDrUL33SchHN93srAmYGzb4CxSM2DPYufe8=
+github.com/things-go/go-socks5 v0.0.5/go.mod h1:mtzInf8v5xmsBpHZVbIw2YQYhc4K0jRwzfsH64Uh0IQ=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -51,6 +51,8 @@ func Options() *common.Options {
 	flag.StringVar(&opt.Output, "o", "", "")
 	flag.StringVar(&opt.Output, "output", "", "")
 
+	flag.StringVar(&opt.Type, "type", "http", "http | socks5")
+
 	flag.BoolVar(&doUpdate, "u", false, "")
 	flag.BoolVar(&doUpdate, "update", false, "")
 

--- a/internal/runner/validator.go
+++ b/internal/runner/validator.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"github.com/mubeng/mubeng/pkg/mubeng"
 	"io"
 	"os"
 	"path/filepath"
@@ -45,7 +46,8 @@ func validate(opt *common.Options) error {
 	if err != nil {
 		return err
 	}
-
+	// get server type
+	mubeng.ServerType = opt.Type
 	opt.ProxyManager, err = proxymanager.New(opt.File)
 	if err != nil {
 		return err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,15 +1,21 @@
 package server
 
 import (
-	"net/http"
-	"os"
-	"os/signal"
-
+	"context"
+	"errors"
 	"github.com/elazarl/goproxy"
 	"github.com/henvic/httpretty"
+	"github.com/mbndr/logo"
 	"github.com/mubeng/mubeng/common"
 	"github.com/mubeng/mubeng/internal/proxygateway"
-	"github.com/mbndr/logo"
+	"github.com/things-go/go-socks5"
+	netProxy "golang.org/x/net/proxy"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
 )
 
 // Run proxy server with a user defined listener.
@@ -36,9 +42,27 @@ func Run(opt *common.Options) {
 		ResponseHeader: true,
 		Colors:         true,
 	}
-
+	log = logo.NewLogger(recs...)
 	handler = &Proxy{}
 	handler.Options = opt
+	if opt.Watch {
+		watcher, err := opt.ProxyManager.Watch()
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer watcher.Close()
+		go watch(watcher)
+	}
+	switch opt.Type {
+	case "http":
+		RunHTTPProxyServer(opt)
+	case "socks5":
+		RunSocks5ProxyServer(opt)
+	}
+
+}
+
+func RunHTTPProxyServer(opt *common.Options) {
 	handler.HTTPProxy = goproxy.NewProxyHttpServer()
 	handler.HTTPProxy.OnRequest().DoFunc(handler.onRequest)
 	handler.HTTPProxy.OnRequest().HandleConnectFunc(handler.onConnect)
@@ -51,18 +75,6 @@ func Run(opt *common.Options) {
 		Handler: handler.HTTPProxy,
 	}
 
-	log = logo.NewLogger(recs...)
-
-	if opt.Watch {
-		watcher, err := opt.ProxyManager.Watch()
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer watcher.Close()
-
-		go watch(watcher)
-	}
-
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
 	go interrupt(stop)
@@ -71,6 +83,51 @@ func Run(opt *common.Options) {
 
 	log.Infof("[PID: %d] Starting proxy server on %s", os.Getpid(), opt.Address)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}
+
+func RunSocks5ProxyServer(opt *common.Options) {
+	socksOpts := []socks5.Option{
+		socks5.WithLogger(log),
+		socks5.WithDial(func(ctx context.Context, net_, addr string) (net.Conn, error) {
+			proxy := handler.rotateProxy()
+			parse, err := url.Parse(proxy)
+			if err != nil {
+				return nil, err
+			}
+			if parse.Host == "" {
+				return nil, errors.New("socks5 address invalid")
+			}
+			password, _ := parse.User.Password()
+			auth := &netProxy.Auth{
+				User:     parse.User.Username(),
+				Password: password,
+			}
+			dialer, err := netProxy.SOCKS5("tcp", parse.Host, auth, netProxy.Direct)
+			if err != nil {
+				return nil, err
+			}
+			log.Debugf("proxy server: %v target addr: %v", parse.Host, addr)
+			return dialer.Dial(net_, addr)
+		}),
+	}
+	if opt.Auth != "" {
+		splitN := strings.SplitN(opt.Auth, ":", 2)
+		credentials := socks5.StaticCredentials(map[string]string{splitN[0]: splitN[1]})
+		socksOpts = append(socksOpts, socks5.WithCredential(credentials))
+	}
+	// get socks5 server
+	socks5Server := socks5.NewServer(socksOpts...)
+	log.Infof("%d proxies loaded", opt.ProxyManager.Count())
+	log.Infof("[PID: %d] Starting proxy server on %s", os.Getpid(), opt.Address)
+	if opt.Auth != "" {
+		log.Infof("socks url: socks5://%v@%v", opt.Auth, opt.Address)
+	} else {
+		log.Infof("socks url: socks5://%v", opt.Address)
+	}
+	// start socks5 server
+	if err := socks5Server.ListenAndServe("tcp", opt.Address); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/server/vars.go
+++ b/internal/server/vars.go
@@ -9,12 +9,12 @@ import (
 )
 
 var (
-	handler *Proxy
-	server  *http.Server
-	dump    *httpretty.Logger
-	mime    = "text/plain"
-	log     *logo.Logger
-	ok      = 1
-
-	mutex = sync.Mutex{}
+	handler      *Proxy
+	server       *http.Server
+	dump         *httpretty.Logger
+	mime         = "text/plain"
+	log          *logo.Logger
+	ok           int64
+	currentProxy string
+	mutex        = sync.Mutex{}
 )

--- a/pkg/mubeng/transport.go
+++ b/pkg/mubeng/transport.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/mubeng/mubeng/pkg/helper/awsurl"
 	"h12.io/socks"
@@ -18,7 +19,10 @@ import (
 func Transport(p string) (*http.Transport, error) {
 	var proxyURL *url.URL
 	var err error
-
+	// socks5 server only support socks proxy
+	if ServerType == "socks5" && !strings.HasPrefix(p, "socks") {
+		return nil, fmt.Errorf("%s os not socks proxy", p)
+	}
 	tr := new(http.Transport)
 
 	if awsurl.IsURL(p) {

--- a/pkg/mubeng/vars.go
+++ b/pkg/mubeng/vars.go
@@ -12,3 +12,5 @@ var HopHeaders = []string{
 	"Transfer-Encoding",
 	"Upgrade",
 }
+
+var ServerType string


### PR DESCRIPTION
Added SOCKS5 server functionality to menbug:
![image-20250128231547596](https://github.com/user-attachments/assets/0e859a4a-a51f-4be0-bd45-cebbdd67f35f)
Test command:
```
mubeng -a 0.0.0.0:8080 -f live.txt -r 5 -w --type socks5
```
![image-20250128232402208](https://github.com/user-attachments/assets/8ff9bde2-300f-479e-a1a1-8acc965d148c)
Since this mode only supports SOCKS-type proxies, the `mubeng.Transport` method has been modified:
![image-20250128231908746](https://github.com/user-attachments/assets/6f455fcc-8aa4-4cd5-84d7-49ceb9fbb77b)
The `Proxy.rotateProxy` method was modified because the old implementation would return an empty proxy when `p.Options.Rotate > 1`, due to `ok` being defaulted to 1 on the first fetch. This caused the SOCKS5 proxy to fail. The changes are as follows:

```
func (p *Proxy) rotateProxy() string {
	var proxy string
	var err error

	if ok >= p.Options.Rotate {
		proxy, err = p.Options.ProxyManager.Rotate(p.Options.Method)
		if err != nil {
			log.Fatalf("Could not rotate proxy IP: %s", err)
		}

		if ok >= p.Options.Rotate {
			ok = 1
		}
	} else {
		ok++
	}
	return proxy
}

// NEW
func (p *Proxy) rotateProxy() string {
	if currentProxy == "" || int(ok) >= p.Options.Rotate {
		proxy, err := p.Options.ProxyManager.Rotate(p.Options.Method)
		if err != nil {
			log.Fatalf("Could not rotate proxy IP: %s", err)
		}
		p.mu.Lock()
		currentProxy = proxy
		ok = 1
		p.mu.Unlock()
	} else {
		atomic.AddInt64(&ok, 1)
	}
	return currentProxy
}
```

Apologies for any language issues, as English is not my strong suit.
